### PR TITLE
Enable repo usage outside of GOPATH

### DIFF
--- a/src/common/resource/resource.go
+++ b/src/common/resource/resource.go
@@ -11,17 +11,31 @@ import (
 )
 
 var (
+	// LocalResourcePath is the relative path from the base of the repo
+	// to the resource directory and will be used in case this repo is
+	// not installed within the system's "GOPATH".
+	LocalResourcePath = "src/resources"
+
 	// ResourcePath is the default path to the resource directory.
-	ResourcePath = "/github.com/facebookresearch/Clinical-Trial-Parser/src/resources"
+	ResourcePath = "/github.com/facebookresearch/Clinical-Trial-Parser/" + LocalResourcePath
+
+	// LocalDataPath is the relative path from the base of the repo
+	// to the data directory and will be used in case this repo is
+	// not installed within the system's "GOPATH".
+	LocalDataPath = "data"
 
 	// DataPath is the default path to the data directory.
-	DataPath = "/github.com/facebookresearch/Clinical-Trial-Parser/data"
+	DataPath = "/github.com/facebookresearch/Clinical-Trial-Parser/" + LocalDataPath
 )
 
 // GetResourcePath returns the path to the project's resource directory.
 func GetResourcePath() string {
 	if env := os.Getenv("RESOURCE_PATH"); len(env) != 0 {
 		return env
+	}
+
+	if _, err := os.Stat(LocalResourcePath); err == nil {
+		return LocalResourcePath
 	}
 
 	if env := os.Getenv("GOPATH"); env != "" {
@@ -42,6 +56,10 @@ func GetResourcePath() string {
 func GetDataPath() string {
 	if env := os.Getenv("DATA_PATH"); len(env) != 0 {
 		return env
+	}
+
+	if _, err := os.Stat(LocalDataPath); err == nil {
+		return LocalDataPath
 	}
 
 	if env := os.Getenv("GOPATH"); env != "" {

--- a/src/common/resource/resource_test.go
+++ b/src/common/resource/resource_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+
+package resource
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+const (
+	dataPathEnvVar     = "DATA_PATH"
+	resourceDir        = "src/common/resource"
+	resourcePathEnvVar = "RESOURCE_PATH"
+)
+
+func TestGetResourcePath(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourcePath string
+		want         string
+	}{
+		{
+			name:         "setting RESOURCE_PATH returns its value",
+			resourcePath: "some-value",
+			want:         "some-value",
+		},
+		{
+			name: "no RESOURCE_PATH attempts to use LocalResourcePath",
+			want: "src/resources",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.resourcePath != "" {
+				os.Setenv(resourcePathEnvVar, tt.resourcePath)
+			} else {
+				os.Unsetenv(resourcePathEnvVar)
+			}
+
+			wd, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("os.Getwd: %v", err)
+			}
+			if strings.HasSuffix(wd, resourceDir) {
+				if err := os.Chdir("../../.."); err != nil {
+					t.Fatalf("os.Chdir: %v", err)
+				}
+			}
+
+			if got := GetResourcePath(); got != tt.want {
+				t.Errorf("GetResourcePath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetDataPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		dataPath string
+		want     string
+	}{
+		{
+			name:     "setting DATA_PATH returns its value",
+			dataPath: "some-value",
+			want:     "some-value",
+		},
+		{
+			name: "no DATA_PATH attempts to use LocalDataPath",
+			want: "data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.dataPath != "" {
+				os.Setenv(dataPathEnvVar, tt.dataPath)
+			} else {
+				os.Unsetenv(dataPathEnvVar)
+			}
+
+			wd, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("os.Getwd: %v", err)
+			}
+			if strings.HasSuffix(wd, resourceDir) {
+				if err := os.Chdir("../../.."); err != nil {
+					t.Fatalf("os.Chdir: %v", err)
+				}
+			}
+
+			if got := GetDataPath(); got != tt.want {
+				t.Errorf("GetDataPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This enables this repo to be used outside of the user's `GOPATH` which is very common now that `go.mod` has been standardized.